### PR TITLE
Feature/ds/7/file descriptor arena

### DIFF
--- a/nfd.c
+++ b/nfd.c
@@ -12,3 +12,11 @@ nfd* create_file(int16_t fd, nfd* prev) {
 	new_file_member->prev = prev;
 	return new_file_member;
 }
+void reap_nfd(nfd* head) {
+	if(head == NULL) {
+		return;
+	}
+	reap_nfd(head->next);
+	free(head);
+	return;
+}

--- a/nfd.h
+++ b/nfd.h
@@ -25,11 +25,11 @@ typedef struct node_fd {
 **/
 nfd* new_file(int16_t fd, nfd* prev);
 
-/*
+/* void reap_nfd(nfd*) -- frees all the memory used by the linked list
+ * Arguments:
+ * nfd* head -- the first member of the doubly-linked list
  *
- *
- *
- *
+ * No return value.
 **/
 void reap_nfd(nfd* head);
 

--- a/nfd.h
+++ b/nfd.h
@@ -25,4 +25,12 @@ typedef struct node_fd {
 **/
 nfd* new_file(int16_t fd, nfd* prev);
 
+/*
+ *
+ *
+ *
+ *
+**/
+void reap_nfd(nfd* head);
+
 #endif


### PR DESCRIPTION
**Issues Referenced:** Closes #7 

**Acceptance Criteria**:
- [x] Add a `typedef struct node_fd {} nfd`, with members `int16_t fd` (signed 16 bit integer), `nfd* prev`, `nfd* next`, and `lbt* head`
- [x] Add a `nfd* new_file(int16_t fd)` function that creates a and returns an `nfd`
- [x] Add a `void reap_nfd(nfd* head)` function that frees all allocated memory on the nfd doubly linked list.

**Addendum(s)**
[From #9] Added parameter `nfd* prev`, which gives `create_file` appending functionality.